### PR TITLE
Easier instrumentation and support for `remoteServiceName`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const { Annotation, Request } = require('zipkin');
+const { Instrumentation } = require('zipkin');
 
 /**
  * Wrapper for the axios HTTP-client.
@@ -88,35 +88,25 @@ class AxiosWrapper {
    *
    */
   sendRequest(url, opts) {
-    const { axios, tracer, serviceName } = this;
+    const { axios, tracer, serviceName, remoteServiceName } = this;
     const { method } = opts;
+    const instrumentation = new Instrumentation.HttpClient({ tracer, serviceName, remoteServiceName });
 
     return new Promise((resolve, reject) => {
       tracer.scoped(() => {
-        tracer.setId(tracer.createChildId());
+        const zipkinOpts = instrumentation.recordRequest(opts, url, method);
         const traceId = tracer.id;
 
-        tracer.recordServiceName(serviceName);
-        tracer.recordRpc(method.toUpperCase());
-        tracer.recordBinary('http.url', url);
-        tracer.recordAnnotation(new Annotation.ClientSend());
-
-        const config = Request.addZipkinHeaders(opts, traceId);
-        config.url = url;
         axios.request(config)
         .then(result => {
           tracer.scoped(() => {
-            tracer.setId(traceId);
-            tracer.recordBinary('http.status_code', result.status.toString());
-            tracer.recordAnnotation(new Annotation.ClientRecv());
+            instrumentation.recordResponse(traceId, result.status);
           });
           resolve(result);
         })
         .catch(err => {
           tracer.scoped(() => {
-             tracer.setId(traceId);
-             tracer.recordBinary('request.error', err.toString());
-             tracer.recordAnnotation(new Annotation.ClientRecv());
+             instrumentation.recordError(traceId, err);
            });
            reject(err);
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,7 +97,7 @@ class AxiosWrapper {
         const zipkinOpts = instrumentation.recordRequest(opts, url, method);
         const traceId = tracer.id;
 
-        axios.request(config)
+        axios.request(zipkinOpts)
         .then(result => {
           tracer.scoped(() => {
             instrumentation.recordResponse(traceId, result.status);

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   "homepage": "https://github.com/uschmann/zipkin-instrumentation-axios#readme",
   "dependencies": {
     "axios": "^0.15.3",
-    "zipkin": "^0.6.1"
+    "zipkin": "^0.10.0"
   }
 }


### PR DESCRIPTION
Since `zipkin@0.10.0` there is an `Instrumentation` utility class that provides a `HttpClient` instance which encapsulates most of the instrumentation logic.

With this change we'll benefit from instrumenting the `remoteServiceName` as well if available.